### PR TITLE
feat: barra de progreso en formulario de encuesta

### DIFF
--- a/api/templates/survey_form.html
+++ b/api/templates/survey_form.html
@@ -18,11 +18,25 @@
         button[type=submit]:hover { background: #2980b9; }
         .success { color: green; font-size: 1.1em; margin-top: 20px; display: none; }
         .error { color: red; font-size: 0.9em; margin-top: 10px; display: none; }
+        .progress-wrap { position: sticky; top: 0; background: #fff; padding: 12px 0 8px; z-index: 10; border-bottom: 1px solid #e9ecef; margin-bottom: 20px; }
+        .progress-label { display: flex; justify-content: space-between; font-size: 0.85em; color: #555; margin-bottom: 6px; }
+        .progress-bar-bg { background: #e9ecef; border-radius: 999px; height: 8px; }
+        .progress-bar-fill { background: #3498db; height: 8px; border-radius: 999px; width: 0%; transition: width .3s ease; }
     </style>
 </head>
 <body>
     <h1>{{ survey.title }}</h1>
     <p>Por favor, respondé cada pregunta honestamente. Tus respuestas son confidenciales.</p>
+
+    <div class="progress-wrap">
+      <div class="progress-label">
+        <span id="progress-text">0 / {{ questions|length }} preguntas respondidas</span>
+        <span id="progress-pct">0%</span>
+      </div>
+      <div class="progress-bar-bg">
+        <div class="progress-bar-fill" id="progress-fill"></div>
+      </div>
+    </div>
 
     <form id="survey-form">
         {% set current_block = namespace(value="") %}
@@ -54,6 +68,20 @@
     </form>
 
     <script>
+        const TOTAL = {{ questions|length }};
+
+        function updateProgress() {
+            const answered = new Set(
+                [...document.querySelectorAll('input[type=radio]:checked')].map(r => r.name)
+            ).size;
+            const pct = Math.round((answered / TOTAL) * 100);
+            document.getElementById('progress-fill').style.width = pct + '%';
+            document.getElementById('progress-text').textContent = answered + ' / ' + TOTAL + ' preguntas respondidas';
+            document.getElementById('progress-pct').textContent = pct + '%';
+        }
+
+        document.getElementById('survey-form').addEventListener('change', updateProgress);
+
         document.getElementById('survey-form').addEventListener('submit', async function(e) {
             e.preventDefault();
             const form = e.target;


### PR DESCRIPTION
Closes #31

## Cambios

- Barra de progreso sticky en la parte superior del formulario
- Se actualiza en tiempo real al seleccionar cada respuesta (`change` event)
- Muestra "X / 28 preguntas respondidas" + porcentaje
- Transición CSS suave al avanzar
- Total de preguntas inyectado desde Jinja2 (`{{ questions|length }}`) — no hardcodeado

## Test

1. Abrir link de encuesta
2. Seleccionar respuestas — la barra debe avanzar progresivamente
3. Al completar las 28 preguntas debe mostrar "28 / 28 — 100%"